### PR TITLE
pagination arrows on admin languages page is now aligned to the right…

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -8034,6 +8034,8 @@ a.loader.is-active, a.is-active.loader--mini, a.is-active.loader--small, a.is-ac
 .new-zanata .panel__pager {
   height: 1.5em;
   float: right;
+  position:absolute;
+  right:0;
 }
 .new-zanata .panel__pager li {
   vertical-align: top;


### PR DESCRIPTION
… - resolves a bug in chrome

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-assets/7)
<!-- Reviewable:end -->
