### PR TITLE
homepage changed to zanata.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zanata-assets",
   "description": "The front-end assets for the Zanata Project",
   "version": "0.1.0",
-  "homepage": "https://github.com/lukebrooker/zanata-proto",
+  "homepage": "http://zanata.org/",
   "author": {
     "name": "Red Hat",
     "email": "zanata@redhat.com",


### PR DESCRIPTION
Removed Luke's git link as the homepage url in package.json

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-assets/8)
<!-- Reviewable:end -->
